### PR TITLE
[DFS/BFS] jieun-0327

### DIFF
--- a/jieun/dfs_bfs/미로탈출.py
+++ b/jieun/dfs_bfs/미로탈출.py
@@ -1,0 +1,36 @@
+from collections import deque
+
+N, M = map(int, input().split())
+map_ = []  # ["행"] , 0: 괴물 있음, 1: 괴물 없음
+for _ in range(N):
+    map_.append(input())
+
+# visited[r][c] = (r,c)까지 가는데 방문한 최소 칸 개수. 시작 칸, (r,c)칸 포함.
+visited = [[0 for _ in range(M)] for _ in range(N)]
+steps = [(-1, 0), (0, 1), (1, 0), (0, -1)]  # 상하좌우 인접 칸 상대 위치
+
+q = deque()
+
+# 문제 인덱스에서 1 빼기
+# 시작: (0,0), 끝: (N-1, M-1)
+q.append((0, 0))
+visited[0][0] = 1
+
+# bfs
+while q:
+    r, c = q.popleft()
+    if r == N - 1 and c == M - 1:
+        break
+    for dr, dc in steps:
+        nr = r + dr
+        nc = c + dc
+        if (
+            0 <= nr and nr < N
+            and 0 <= nc and nc < M
+            and map_[nr][nc] == "1"
+            and visited[nr][nc] == 0
+        ):
+            visited[nr][nc] = visited[r][c] + 1
+            q.append((nr, nc))
+
+print(visited[N - 1][M - 1])

--- a/jieun/dfs_bfs/음료수얼려먹기.py
+++ b/jieun/dfs_bfs/음료수얼려먹기.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+N, M = map(int, input().split())
+map_ = []  # ["행"], 0: 구멍, 1: 칸막이
+for _ in range(N):
+    map_.append(input())
+
+visited = [[False for _ in range(M)] for _ in range(N)]  # 방문 여부 기록
+steps = [(-1, 0), (0, 1), (1, 0), (0, -1)]  # 상하좌우 인접 칸 상대 위치
+
+
+def bfs(sr, sc):
+    # (sr,sc)와 연결된 모든 칸을 방문한다.
+    q = deque()
+    visited[sr][sc] = True
+    q.append((sr, sc))
+    while q:
+        r, c = q.popleft()
+        for dr, dc in steps:
+            nr = r + dr
+            nc = c + dc
+            if (
+                0 <= nr and nr < N
+                and 0 <= nc and nc < M
+                and map_[nr][nc] == "0"
+                and not visited[nr][nc]
+            ):
+                # map_ 범위 안에 속하고, 구멍이고, 방문하지 않은 칸이면
+                visited[nr][nc] = True
+                q.append((nr, nc))
+
+
+ans = 0
+for i in range(N):
+    for j in range(M):
+        if map_[i][j] == "0" and not visited[i][j]:
+            # 구멍이고, 방문하지 않은 칸이면
+            ans += 1
+            bfs(i, j)  # 해당 아이스크림에 속하는 칸 전체를 찾는다.
+
+print(ans)


### PR DESCRIPTION
### 📌 푼 문제들

- 음료수 얼려 먹기
- 미로 탈출

---

### 📝 간단한 풀이 과정

#### 음료수 얼려 먹기

- 방문 안 한 얼음 구멍에 대해 BFS를 돌린다.
- BFS는 시작 구멍 칸과 연결된 모든 칸을 방문해서 하나의 아이스크림을 찾는다.

#### 미로 탈출

- 동빈이의 위치(0,0)에서 BFS를 시작하고 출구(N-1, M-1)를 방문하면 끝낸다.
- `visited[r][c]`는 시작칸에서 (r,c)칸까지 가는데 방문한 최소 칸 수를 저장한다. 시작칸도 포함한다. 0으로 초기화되어 있다.
- 방문한 칸을 다시 방문하지 않는다. BFS는 여러 경로를 동시에 탐색하되 다 같이 한 칸씩 확장하므로, 다시 방문할 때 거친 칸 수가 전에 방문했을 때보다 같거나 많기 때문이다.

---
