### PR TITLE
[DFS/BFS] yunjin-0327

### DIFF
--- a/yunjin/DFSBFS/미로 탈출.py
+++ b/yunjin/DFSBFS/미로 탈출.py
@@ -1,0 +1,42 @@
+from collections import deque
+
+N, M = map(int, input().split())
+
+map_ = []
+for i in range(N):
+    map_.append(list(map(int, str(input()))))
+
+visited = [[False for c in range(M)] for r in range(N)]
+
+# 북 동 남 서
+dr = [-1, 0, 1, 0]
+dc = [0, 1, 0, -1]
+
+
+def BFS(row, col, time):
+    d = deque()
+    d.append((row, col, time))
+    visited[row][col] = True
+
+    while d:
+        r, c, t = d.popleft()
+
+        # 탈출 지점
+        if r == N - 1 and c == M - 1:
+            return t + 1  # 마지막 칸에 도착하고 다음 칸에 탈출하므로 +1 해준다.
+
+        for i in range(4):
+            nr = r + dr[i]
+            nc = c + dc[i]
+
+            if nr < 0 or nr >= N or nc < 0 or nc >= M:
+                continue
+
+            # 갈 수 있는 지점을 방문하지 않은 경우에만 이동. 시간 초 증가
+            if map_[nr][nc] == 1 and not visited[nr][nc]:
+                d.append((nr, nc, t + 1))
+                visited[nr][nc] = True
+
+
+# 최소 거리 탈출 조건 -> BFS
+print(BFS(0, 0, 0))

--- a/yunjin/DFSBFS/음료수 얼려먹기.py
+++ b/yunjin/DFSBFS/음료수 얼려먹기.py
@@ -1,0 +1,46 @@
+import sys
+from collections import deque
+
+N, M = map(int, input().split())
+
+# 맵 선언
+map_ = []
+for i in range(N):
+    map_.append(list(map(int, str(input()))))
+
+# 방문 배열
+visited = [[False for col in range(M)] for row in range(N)]
+
+# 북, 동, 남, 서
+dr = [-1, 0, 1, 0]
+dc = [0, 1, 0, -1]
+
+def BFS(r, c):
+    d = deque()
+    d.append((r, c))
+    visited[r][c] = True
+
+    while d:
+        r, c = d.popleft()
+
+        for i in range(4):
+            nr = r + dr[i]
+            nc = c + dc[i]
+
+            # 밖으로는 안됨
+            if nr < 0 or nr >= N or nc < 0 or nc >= M:
+                continue
+
+            if map_[nr][nc] == map_[r][c] and not visited[nr][nc]:
+                d.append((nr, nc))
+                visited[nr][nc] = True
+
+
+icecream_cnt = 0
+for r in range(N):
+    for c in range(M):
+        if map_[r][c] == 0 and not visited[r][c]:
+            BFS(r, c)
+            icecream_cnt += 1
+
+print(icecream_cnt)


### PR DESCRIPTION
### 📌 푼 문제들

- 음료수 얼려먹기
- 미로 탈출

---

### 📝 간단한 풀이 과정

#### 음료수 얼려먹기

- 풀이과정
1.  map_ 에 대해서 BFS 를 이용하여 영역을 나눠주었습니다.

#### 미로 탈출

- 풀이과정
1.  BFS를 진행하며 데큐에  time을 함께 받아서 각 칸을 최소 몇 초에 도착하는 지  확인했습니다. 
2. 탈출 조건을 만나면 time+1 을 리턴해주고 종료해줬습니다.
