### PR TITLE
[DFS/BFS] jieun-0328

### DIFF
--- a/jieun/dfs_bfs/Q15_특정거리의도시찾기.py
+++ b/jieun/dfs_bfs/Q15_특정거리의도시찾기.py
@@ -1,0 +1,34 @@
+# 백준 18352 맞음: 100284 KB, 1456 ms, Python3
+import sys
+from collections import deque
+
+N, M, K, X = map(int, sys.stdin.readline().rstrip().split())
+edge = [[] for _ in range(N + 1)]  # 인덱스 1부터 시작
+for _ in range(M):
+    A, B = map(int, sys.stdin.readline().rstrip().split())
+    edge[A].append(B)
+
+# 방문하지 않은 도시는 -1. 방문한 도시는 최단거리를 기록한다.
+dist = [-1 for _ in range(N + 1)]
+q = deque()
+
+ans = []
+dist[X] = 0
+q.append(X)
+while q:
+    cur = q.popleft()
+    if dist[cur] == K: # 거리가 K인 도시는 답에 넣고 다음 루프를 돈다.
+        ans.append(cur)
+        continue
+
+    for nxt in edge[cur]:
+        if dist[nxt] == -1:  # 방문하지 않은 도시만 탐색한다.
+            dist[nxt] = dist[cur] + 1
+            q.append(nxt)
+
+if len(ans) == 0:
+    print(-1)
+else:
+    ans.sort()
+    for x in ans:
+        print(x)

--- a/jieun/dfs_bfs/Q16_연구소.py
+++ b/jieun/dfs_bfs/Q16_연구소.py
@@ -1,0 +1,69 @@
+# 백준 14502 맞음: 34216 KB, 2968 ms, Python3
+import sys
+import itertools
+from collections import deque
+
+N, M = map(int, sys.stdin.readline().rstrip().split())
+total = N * M  # 총 칸 개수
+map_ = []  # 0: 빈칸, 1: 벽, 2: 바이러스
+# r행 c열 인덱스: r*M + c
+for _ in range(N):  # 1차원으로 입력받는다.
+    map_.extend(list(map(int, sys.stdin.readline().rstrip().split())))
+
+# 2차원일 때 인접 칸 상대 위치
+steps = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+
+
+def bfs(visited, start):
+    # start(바이러스)에서 연결된 빈 칸들을 방문한다.
+    q = deque()
+    visited[start] = True
+    q.append(start)
+    while q:
+        cur = q.popleft()
+        for dr, dc in steps:
+            # 인덱스에서 행과 열 계산
+            nr = cur // M + dr
+            nc = cur % M + dc
+            if nr in [-1, N] or nc in [-1, M]:
+                continue
+            nidx = nr * M + nc
+            if map_[nidx] == 0 and not visited[nidx]:
+                # 아직 방문하지 않은 빈 칸이면 방문
+                visited[nidx] = True
+                q.append(nidx)
+
+
+ans = 0
+
+arr = [i for i in range(total)]
+# [0, 1, ..., N*M-1] 중 3개를 고르는 조합
+for one, two, three in itertools.combinations(arr, 3):
+    # 고른 3 칸이 빈 칸이 아니면 다시 고른다.
+    if map_[one] != 0 or map_[two] != 0 or map_[three] != 0:
+        continue
+
+    # 고른 3 칸을 벽으로 변환
+    map_[one] = 1
+    map_[two] = 1
+    map_[three] = 1
+
+    # 바이러스 칸에 대해 bfs를 돈다.
+    visited = [False for _ in range(total)]
+    for idx in range(total):
+        if map_[idx] == 2:
+            bfs(visited, idx)
+
+    # 빈 칸인 개수를 세고 답을 갱신한다.
+    cnt = 0
+    for idx in range(total):
+        if map_[idx] == 0 and not visited[idx]:
+            cnt += 1
+    ans = max(ans, cnt)
+
+    # 고른 3 칸 빈 칸으로 원상복귀
+    map_[one] = 0
+    map_[two] = 0
+    map_[three] = 0
+
+print(ans)


### PR DESCRIPTION
### 📌 푼 문제들

- 특정 거리의 도시 찾기
- 연구소

---

### 📝 간단한 풀이 과정

#### 특정 거리의 도시 찾기

- 도시 `X`에서 bfs를 시작한다. 처음 방문했을 때 `dist`에 거리를 기록한다.
- bfs 수행 중, deque에서 꺼낸 도시의 `dist`값이 `K`이면 `ans`에 넣고, deque에서 다른 도시를 꺼낸다.

#### 연구소
 
0. `map_`은 입력받은 맵을 1차원으로 변환해 저장한다. r행 c열의 인덱스: $r \times M+c$.
1. 빈 칸 중 3개의 칸을 선택해서 벽으로 바꾼다. 
2. 각 바이러스 칸을 시작으로 bfs를 돈다. `visited`에 방문 여부를 저장한다. bfs는 방문하지 않은 빈 칸만 방문한다.
3. 방문할 수 있는 모든 빈 칸을 방문한 후, 방문하지 않은 빈 칸의 개수를 세고 답을 갱신한다.
4. 빈 칸 중 3 개를 선택하는 모든 조합에 대해 1~3을 수행한다.
시간 복잡도는 $O(_{N \times M} C_3 \times N \times M)$ 으로 최악의 경우 $_64 C_3 \times 64 = 2666496$ ($10^6$ 단위)이므로 모든 경우를 탐색할 수 있다.

---
