### PR TITLE
[DFS/BFS] jieun-0329

### DIFF
--- a/jieun/dfs_bfs/Q17_경쟁적전염.py
+++ b/jieun/dfs_bfs/Q17_경쟁적전염.py
@@ -1,0 +1,29 @@
+import sys
+from collections import deque
+
+N, K = map(int, sys.stdin.readline().rstrip().split())
+map_ = []
+for _ in range(N):
+    map_.append(list(map(int, sys.stdin.readline().rstrip().split())))
+S, X, Y = map(int, sys.stdin.readline().rstrip().split())
+
+# 바이러스 칸만 추출
+virus = [(r, c, 0) for c in range(N) for r in range(N) if map_[r][c] > 0]
+virus.sort(key=lambda x: map_[x[0]][x[1]])  # 바이러스 종류 오름차순으로 정렬
+
+step = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+q = deque(virus)
+while q:
+    r, c, time = q.popleft()
+    if time == S:
+        # S초인 칸이 처음 나왔을 때 바로 탈출
+        break
+    for dr, dc in step:
+        nr = r + dr
+        nc = c + dc
+        if nr in [-1, N] or nc in [-1, N] or map_[nr][nc] > 0:
+            continue
+        map_[nr][nc] = map_[r][c]
+        q.append((nr, nc, time + 1))
+
+print(map_[X - 1][Y - 1])

--- a/jieun/dfs_bfs/Q18_괄호변환.py
+++ b/jieun/dfs_bfs/Q18_괄호변환.py
@@ -1,0 +1,58 @@
+def is_right(u):
+    # u가 올바른 문자열인지 반환한다.
+    stack = []
+    for ch in u:
+        if ch == "(":
+            stack.append(ch)
+        elif len(stack) == 0:
+            # ")"와 쌍을 이룰 "("가 없다
+            return False
+        else:
+            stack.pop()
+    if len(stack) == 0:
+        # "()" 모두 쌍을 이룬다.
+        return True
+    else:
+        # "("만 남아있다.
+        return False
+
+
+def find_(s):
+    if s == "":  # 빈 문자열 반환
+        return ""
+    
+    left = 0 # "(" 개수
+    right = 0 # ")" 개수
+    # left == right 일 때의 idx를 구한다.
+    for idx, ch in enumerate(s):
+        if ch == "(":
+            left += 1
+        else:
+            right += 1
+        if left == right:
+            break
+    
+    # u,v 찾기
+    u = s[: idx + 1]
+    v = s[idx + 1 :] if idx + 1 < len(s) else ""
+
+    res_list = []
+    if is_right(u): 
+        # u가 올바른 문자열이면 u + v에 1단계
+        res_list = [u, find_(v)]
+    else:
+        # u가 올바른 문자열이 아니면
+        # ( + {v에 1단계} + ) + {u의 첫 번째와 마지막 문자 제거한 문자열의 반대 괄호}
+        res_list = ["(", find_(v), ")"]
+        for ch in u[1 : len(u) - 1]:
+            if ch == "(":
+                res_list.append(")")
+            else:
+                res_list.append("(")
+                
+    return "".join(res_list) # res_list에 있는 문자들을 붙여 문자열로 만든다.
+
+
+def solution(p):
+    answer = find_(p)
+    return answer


### PR DESCRIPTION
### 📌 푼 문제들

- 경쟁적 전염
- 괄호 변환

---

### 📝 간단한 풀이 과정

#### 경쟁적 전염

- `virus`에 바이러스 칸만 저장하고, 종류 기준 오름차순으로 정렬한다. `(행, 열, 0초)`
- deque에 `virus`를 넣고 bfs를 시작한다. 같은 시간에 종류 0부터 탐색하는 순서는 유지된다.
- deque에서 꺼낸 칸의 시간이 `S`초이면 bfs를 멈춘다.

#### 괄호 변환 

- 문자열 s에 대해 1단계부터 실행하는 함수 `find_(s)`를 재귀적으로 호출한다. `find_()`는 다음 과정을 수행한다. (문제에서 주어진 내용 정리)

1. 빈 문자열이면 그대로 반환한다.
2. '('와 ')' 개수가 같아지는 인덱스를 구하고, 인덱스를 기준으로 문자열을 u,v로 나눈다.
3. `is_right()`로 문자열 u가 올바른 문자열인지 확인한다. 맞으면 `u + find_(v)`를 반환한다.
4. 맞지 않으면 `( + find_(v) + )`에 `u[1 : len(u)-1]`의 괄호를 반대로 한 문자열을 붙여 반환한다.

- `is_right()`는 '('는 스택에 넣고, ')'가 들어오면 스택에서 하나를 빼면서 모두 쌍을 이루는지 확인한다. 

---
