### PR TITLE
[정렬] jieun-0406

### DIFF
--- a/jieun/정렬/Q25_실패율.py
+++ b/jieun/정렬/Q25_실패율.py
@@ -1,0 +1,17 @@
+def solution(N, stages):
+    cnt = [0 for _ in range(N + 2)]  # 스테이지에 멈춰있는 플레이어 수
+    for s in stages:
+        cnt[s] += 1
+
+    fail = [0] # 실패율
+    for i in range(1, N + 1):
+        a = sum(cnt[i:])  # 스테이지에 도달한 총 플레이어 수
+        if a > 0.0:
+            fail.append(cnt[i] / a)
+        else:
+            fail.append(cnt[i])
+
+    answer = [x for x in range(1, N + 1)]
+    answer.sort(key=lambda x: (-fail[x], x))
+
+    return answer

--- a/jieun/정렬/Q26_카드정렬하기.py
+++ b/jieun/정렬/Q26_카드정렬하기.py
@@ -1,0 +1,15 @@
+import sys
+import heapq as h
+
+N = int(sys.stdin.readline().rstrip())
+cards = [int(sys.stdin.readline().rstrip()) for _ in range(N)]
+
+cnt = 0
+h.heapify(cards)  # cards를 min heap으로 변환
+while len(cards) > 1:
+    # 가장 작은 두 묶음을 더함
+    new = h.heappop(cards) + h.heappop(cards)
+    cnt += new
+    h.heappush(cards, new)
+
+print(cnt)


### PR DESCRIPTION
### 📌 푼 문제들

- 실패율
- 카드 정렬하기

---

### 📝 간단한 풀이 과정

#### 실패율

- `cnt[x]`: x 번째 스테이지에 멈춰있는 플레이어 수
- `fail[x]`: x 번째 스테이지의 실패율 = `cnt[x] / sum(cnt[x:])`
- key에 `fail` 함수를 사용해서 스테이지 인덱스를 정렬한다.

#### 카드 정렬하기

- 카드 묶음의 개수들을 heap에 넣는다.
- 가장 작은 두 묶음을 heap에서 꺼내 더해서 새로운 묶음을 만든다.
- 새로운 묶음의 개수를 답에 더하고, heap에 넣는다.
- heap에 묶음이 하나밖에 남지 않을 때까지 위 과정을 반복한다.

---
