### PR TITLE
[이진탐색] jieun 0421

### DIFF
--- a/jieun/이진탐색/Q29_공유기설치.py
+++ b/jieun/이진탐색/Q29_공유기설치.py
@@ -1,0 +1,35 @@
+import sys
+
+N, C = map(int, sys.stdin.readline().rstrip().split())
+house = [int(sys.stdin.readline().rstrip()) for _ in range(N)]
+house.sort()  # 집 위치 오름차순 정렬
+
+
+def check(d):
+    # 인접한 두 공유기의 거리가 최소 d일 수 있으면 True
+
+    cnt = 1  # 0번째 집에 설치해서 1부터 시작
+    s = 0  # 설치된 집
+    e = 1  # 설치할 수 있을 지 보는 집
+
+    while e < N and cnt < C:
+        # 거리가 d 이상인 집에 설치
+        if house[e] - house[s] >= d:
+            cnt += 1
+            s = e
+        e += 1
+    return cnt == C
+
+
+# TTTFFF로 이분됨.
+lo = 1
+hi = house[N - 1] + 1  # 집 위치가 0부터 시작하므로
+
+while lo + 1 < hi:
+    mid = (lo + hi) // 2
+    if check(mid):
+        lo = mid
+    else:
+        hi = mid
+
+print(lo)

--- a/jieun/이진탐색/Q30_가사검색.py
+++ b/jieun/이진탐색/Q30_가사검색.py
@@ -1,0 +1,92 @@
+def lower_bound(query: str, char_len: int, symb_len: int, words):
+    q = query[:char_len]
+    lo = -1
+    hi = len(words)
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        # mid >= target FFFTTT
+        if words[mid][:char_len] > q or (
+            words[mid][:char_len] == q and len(words[mid]) - char_len >= symb_len
+        ):
+            hi = mid
+        else:
+            lo = mid
+    return hi
+
+
+def upper_bound(query: str, char_len: int, symb_len: int, words):
+    q = query[:char_len]
+    lo = -1
+    hi = len(words)
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        # mid > target FFFTTT
+        if words[mid][:char_len] > q or (
+            words[mid][:char_len] == q and len(words[mid]) - char_len > symb_len
+        ):
+            hi = mid
+        else:
+            lo = mid
+    return hi
+
+
+def find_question(query: str):
+    # aaa???
+    lo = -1
+    hi = len(query) - 1
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        # is ?: FFFTTT
+        if query[mid] == "?":
+            hi = mid
+        else:
+            lo = mid
+    return hi
+
+
+def solution(words, queries):
+    answer = []
+    cnt = dict()
+
+    backward_words = ["".join(reversed(w)) for w in words]
+    backward_words.sort()
+    words.sort()
+
+    print("words:", words)
+    print("backward_words:", backward_words)
+    print("queries:", queries)
+
+    for q in queries:
+        if q[0] == "?":
+            q = "".join(reversed(q))
+            print(f"{''.join(reversed(q))} --> {q} :", end=" ")
+            if q in cnt:
+                answer.append(cnt[q])
+            else:
+                idx = find_question(q)
+                u = upper_bound(q, idx, len(q) - idx, backward_words)
+                l = lower_bound(q, idx, len(q) - idx, backward_words)
+        else:
+            print(q, ":", end=" ")
+            if q in cnt:
+                answer.append(cnt[q])
+            else:
+                idx = find_question(q)
+                u = upper_bound(q, idx, len(q) - idx, words)
+                l = lower_bound(q, idx, len(q) - idx, words)
+
+        print(u, l)
+        res = u - l
+        cnt[q] = res
+        answer.append(res)
+
+    return answer
+
+
+if __name__ == "__main__":
+    words = ["frodo", "front", "frost", "frozen", "frame", "kakao"]
+    queries = ["fro??", "????o", "fr???", "fro???", "pro?"]
+    ans = [3, 2, 4, 1, 0]
+    res = solution(words, queries)
+    print(res, ans)
+    print(res == ans)


### PR DESCRIPTION
### 📌 푼 문제들

- [공유기 설치]
- [가사검색]

---

### 📝 간단한 풀이 과정

#### [공유기 설치]

- 집 위치 오름차순 정렬
- $d \in [1, 마지막 \\; 집 \\; 위치\\;]$ 에 대해 이분 탐색
- `조건: 인접한 두 공유기의 최소 거리가 d 이상` 을 만족하는 가장 큰 d 찾기 (TTTFFF)

#### [가사 검색] 

처음 풀이를 틀리고 아이디어가 생각이 안 나서 검색 했습니다.

- 트라이 구조 사용
  - `Node.cnt` : defaultdict. `cnt[len]`은 루트에서 현재 노드까지를 접두사로 가지는 문자열 중 뒤 길이가 len인 문자열 개수
  - `Trie.insert(str)` : 문자열 `str`를 트라이에 넣는다. 방문하는 각 노드마다 `cnt`에 1 증가
  - `Trie.search(prefix, symb_len)` 문자열 prefix와 symb_len 개의 '?'로 이루어진 쿼리에 해당하는 문자열 개수 반환
- `words`를 넣은 `trie`, `words` 속 각 단어를 뒤집은 `reverse_trie`를 생성한다.
- 쿼리에 물음표가 뒤에 있으면 `trie`를 탐색. 쿼리에 물음표가 앞에 있으면, 쿼리를 뒤집고 `reverse_trie` 탐색
- 쿼리에서 물음표가 처음 나오는 인덱스를 이진탐색. `Trie.search()` 호출

#### 틀린 풀이

- words를 정렬.
- 물음표가 뒤에 있는 쿼리에 대해 upper_bound(words, query) - lower_bound(words, query) 를 구함
- 물음표가 앞에 있는 쿼리는 뒤집고, words 각 단어를 뒤집은 backward_words에서 진행
```
query가 소문자 a개 물음표 b 개로 이루어져 있을 때,
word > query 뜻 :
1. word[:a] > query[:a]
2. word[:a] == query[:a] and len(word) - a > b
```

---

### 🙌 궁금한 점

- 가사 검색 틀린 풀이가 왜 틀렸는지 모르겠습니다...
- 트라이 코드 참고: https://m.blog.naver.com/cjsencks/221740232900

---
